### PR TITLE
SMR-2449 iOS: Create privacy manifest and Missing API declaration acc…

### DIFF
--- a/ios/PrivacyInfo.xcprivacy
+++ b/ios/PrivacyInfo.xcprivacy
@@ -12,38 +12,38 @@
       <array>
          <dict>
             <key>NSPrivacyAccessedAPIType</key>
-            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+               <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
             <key>NSPrivacyAccessedAPITypeReasons</key>
-            <array>
-               <string>3B52.1</string>
-            </array>
+               <array>
+                  <string>3B52.1</string>
+               </array>
          </dict>
 
          <dict>
             <key>NSPrivacyAccessedAPIType</key>
-            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+               <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
             <key>NSPrivacyAccessedAPITypeReasons</key>
-            <array>
-               <string>CA92.1</string>
-            </array>
+               <array>
+                  <string>CA92.1</string>
+               </array>
          </dict>
 
          <dict>
             <key>NSPrivacyAccessedAPIType</key>
-                  <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+               <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
             <key>NSPrivacyAccessedAPITypeReasons</key>
-            <array>
-                <string>35F9.1</string>
-            </array>
+               <array>
+                  <string>35F9.1</string>
+               </array>
          </dict>
 
          <dict>
-               <key>NSPrivacyAccessedAPIType</key>
-            <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+            <key>NSPrivacyAccessedAPIType</key>
+               <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
             <key>NSPrivacyAccessedAPITypeReasons</key>
-            <array>
-               <string>E174.1</string>
-            </array>
+               <array>
+                  <string>E174.1</string>
+               </array>
          </dict>
       </array>
    </dict>

--- a/ios/PrivacyInfo.xcprivacy
+++ b/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+   <dict>
+      <key>NSPrivacyTracking</key>
+      <false/>
+      <key>NSPrivacyTrackingDomains</key>
+      <array/>
+      <key>NSPrivacyCollectedDataTypes</key>
+      <array/>
+      <key>NSPrivacyAccessedAPITypes</key>
+      <array>
+         <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+               <string>3B52.1</string>
+            </array>
+         </dict>
+
+         <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+               <string>CA92.1</string>
+            </array>
+         </dict>
+
+         <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+                  <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>35F9.1</string>
+            </array>
+         </dict>
+
+         <dict>
+               <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+               <string>E174.1</string>
+            </array>
+         </dict>
+      </array>
+   </dict>
+</plist>


### PR DESCRIPTION
### iOS: Create privacy manifest and Missing API declaration according to new Apple's rules