### PR TITLE
SMR-6412: iOS: Retain TVOCallInvite after reject to prevent SDK crash on late cancel

### DIFF
--- a/ios/TwilioVoiceReactNative+CallKit.m
+++ b/ios/TwilioVoiceReactNative+CallKit.m
@@ -301,6 +301,18 @@ NSString * const kCustomParametersKeyCallerName = @"CallerName";
                              kTwilioVoiceReactNativeCallInviteEventKeyCallSid: callInvite.callSid,
                              kTwilioVoiceReactNativeEventKeyCallInvite: [self callInviteInfo:callInvite]}];
         [self.callInviteMap removeObjectForKey:action.callUUID.UUIDString];
+
+        // Keep TVOCallInvite alive for a few seconds after reject so the
+        // underlying Twilio Voice iOS SDK can finish rejection signaling and
+        // safely handle a late-arriving cancellation event without
+        // dereferencing a freed object. The dispatch_after block strongly
+        // retains `callInvite` until it runs, then releases it.
+        // See TVOCallInvite lifecycle contract:
+        // https://www.twilio.com/docs/voice/sdks/ios/changelog
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
+            NSLog(@"[TwilioVoiceReactNative] Releasing retained TVOCallInvite for callSid %@", callInvite.callSid);
+        });
     }
     
     [action fulfill];


### PR DESCRIPTION
### SMR-6412: iOS: Retain TVOCallInvite after reject to prevent SDK crash on late cancel

https://salesmsg.atlassian.net/browse/SMR-6412


Twilio's iOS SDK requires the application to keep TVOCallInvite alive
until the call invite has been fully accepted, rejected or cancelled.
The previous code removed the entry from callInviteMap synchronously
after [callInvite reject], releasing the ObjC object while the SDK's
internal C++ adapter still held a raw pointer to it. When a cancel
signal arrived right after reject (a common race when the remote side
hangs up at the same moment), MessageObserverAdapter::onCallInviteCancelled
dereferenced the freed object → EXC_BAD_ACCESS / KERN_INVALID_ADDRESS
at offset 0x18.

Fix:
- Bump TwilioVoice pod to 6.13.5 (contains the upstream defensive fix
  in onCallInviteCancelled).
- As an extra safety net, retain the TVOCallInvite for 5s after reject
  via a strong block capture inside dispatch_after on the main queue.

Refs: https://www.twilio.com/docs/voice/sdks/ios/changelog (6.13.4 fix)